### PR TITLE
fix to typedefs for Typescript 2.7

### DIFF
--- a/packages/mobx-state-tree/src/types/complex-types/model.ts
+++ b/packages/mobx-state-tree/src/types/complex-types/model.ts
@@ -191,7 +191,7 @@ export class ModelType<S, T> extends ComplexType<S, T> implements IModelType<S, 
 
     props<SP, TP>(
         properties: { [K in keyof TP]: IType<any, TP[K]> } & { [K in keyof SP]: IType<SP[K], any> }
-    ): IModelType<S & SP, T & TP> {
+    ): IModelType<S & SP & Snapshot<SP>, T & TP> {
         return this.cloneAndEnhance({ properties } as any)
     }
 
@@ -480,11 +480,12 @@ export type Snapshot<T> = {
     [K in keyof T]?: Snapshot<T[K]> | any // Any because we cannot express conditional types yet, so this escape is needed for refs and such....
 }
 
+export function model<T = {}>(): IModelType<T | Snapshot<T>, T>
+export function model<T = {}>(properties: IModelProperties<T>): IModelType<Snapshot<T>, T>
 export function model<T = {}>(
     name: string,
-    properties?: IModelProperties<T>
-): IModelType<Snapshot<T>, T>
-export function model<T = {}>(properties?: IModelProperties<T>): IModelType<Snapshot<T>, T>
+    properties: IModelProperties<T>
+): IModelType<T | Snapshot<T>, T>
 /**
  * Creates a new model type by providing a name, properties, volatile state and actions.
  *
@@ -493,10 +494,11 @@ export function model<T = {}>(properties?: IModelProperties<T>): IModelType<Snap
  * @export
  * @alias types.model
  */
-export function model(...args: any[]) {
-    const name = typeof args[0] === "string" ? args.shift() : "AnonymousModel"
+export function model<T = {}>(...args: any[]): IModelType<T | Snapshot<T>, T> {
+    const name = typeof args[0] === "string" ? (args.shift() as string) : "AnonymousModel"
     const properties = args.shift() || {}
-    return new ModelType({ name, properties })
+    const config = {name: (name as string), properties} as ModelTypeConfig
+    return new ModelType(config)
 }
 
 export function compose<T1, S1, T2, S2, T3, S3>(

--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -51,7 +51,7 @@ export function extendKeepGetter(a: any, ...b: any[]) {
     for (let i = 0; i < b.length; i++) {
         const current = b[i]
         for (let key in current) {
-            const descriptor = Object.getOwnPropertyDescriptor(current, key)
+            const descriptor = Object.getOwnPropertyDescriptor(current, key) || {}
             if ("get" in descriptor) {
                 Object.defineProperty(a, key, { ...descriptor, configurable: true })
                 continue


### PR DESCRIPTION
Related to #629 and #635.

These changes compile using the latest  typescript (using `npm run quick-build`) but I don't know enough to know if they're correct or if a there's a better alternative.